### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,9 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
       with:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
# Harden GitHub Actions workflows

**Refs:** PSEC-923

This PR applies two small, low-risk security hardening changes to the
repository's GitHub Actions workflows. Both are behavior-preserving for CI.

## Changes

- **Disable credential persistence on checkout** (`test.yml`): set
  `persist-credentials: false` on the `actions/checkout` step. The job only
  runs `go test` and performs no git write operations, so the `GITHUB_TOKEN`
  does not need to be persisted into the local git config — where a later
  step could otherwise read or leak it.

- **Suppress two cosmetic zizmor findings via config** (`.github/zizmor.yml`):
  disable the `anonymous-definition` and `concurrency-limits` pedantic rules
  (consistent with the rest of our workflow-hardening campaign), and add
  `.github/zizmor.yml` to the Zizmor workflow's trigger paths so the config is
  re-linted when it changes. The existing `dependabot-cooldown` config is
  preserved.

No findings were deferred to manual review for this repository.
